### PR TITLE
Reminder Entity, with get all and post for a User

### DIFF
--- a/src/main/java/com/codeday/productivity/controller/ReminderController.java
+++ b/src/main/java/com/codeday/productivity/controller/ReminderController.java
@@ -1,0 +1,10 @@
+package com.codeday.productivity.controller;
+
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/v1/users/{userId}/reminder")
+public class ReminderController {
+}

--- a/src/main/java/com/codeday/productivity/controller/ReminderController.java
+++ b/src/main/java/com/codeday/productivity/controller/ReminderController.java
@@ -1,10 +1,28 @@
 package com.codeday.productivity.controller;
 
-
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import com.codeday.productivity.entity.Reminder;
+import com.codeday.productivity.service.ReminderService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/v1/users/{userId}/reminder")
 public class ReminderController {
+
+    private final ReminderService reminderService;
+
+    @Autowired
+    public ReminderController(ReminderService reminderService) {
+        this.reminderService = reminderService;
+    }
+
+    @PostMapping
+    public Reminder createUserReminder(@PathVariable Integer userId, @RequestBody Reminder reminder) {
+        return reminderService.createUserReminder(userId, reminder);
+    }
+
+    @GetMapping
+    public Iterable<Reminder> getUserReminders(@PathVariable Integer userId) {
+        return reminderService.getUserReminders(userId);
+    }
 }

--- a/src/main/java/com/codeday/productivity/controller/ReminderController.java
+++ b/src/main/java/com/codeday/productivity/controller/ReminderController.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/v1/users/{userId}/reminder")
+@RequestMapping("/v1/users/{userId}/reminders")
 public class ReminderController {
 
     private final ReminderService reminderService;

--- a/src/main/java/com/codeday/productivity/controller/ReminderController.java
+++ b/src/main/java/com/codeday/productivity/controller/ReminderController.java
@@ -6,7 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/v1/users/{userId}/reminders")
+@RequestMapping("/api/v1/users/{userId}/reminders")
 public class ReminderController {
 
     private final ReminderService reminderService;

--- a/src/main/java/com/codeday/productivity/entity/Reminder.java
+++ b/src/main/java/com/codeday/productivity/entity/Reminder.java
@@ -1,5 +1,6 @@
 package com.codeday.productivity.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -16,7 +17,10 @@ public class Reminder {
     @GeneratedValue
     private Long id;
 
-    // relationship to User
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    @JsonBackReference(value="user-reminder")
+    private User user;
 
     @Column(nullable = false)
     private String message;

--- a/src/main/java/com/codeday/productivity/entity/Reminder.java
+++ b/src/main/java/com/codeday/productivity/entity/Reminder.java
@@ -1,0 +1,25 @@
+package com.codeday.productivity.entity;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "REMINDER_TABLE")
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class Reminder {
+
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    // relationship to User
+
+    @Column(nullable = false)
+    private String message;
+
+    // Scheduled Time (initial time for reminder, repeats ? until marked done)
+}

--- a/src/main/java/com/codeday/productivity/entity/Reminder.java
+++ b/src/main/java/com/codeday/productivity/entity/Reminder.java
@@ -14,7 +14,8 @@ import lombok.NoArgsConstructor;
 public class Reminder {
 
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "reminder_sequence")
+    @SequenceGenerator(name = "reminder_sequence", sequenceName = "reminder_sequence", allocationSize = 1)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/codeday/productivity/entity/User.java
+++ b/src/main/java/com/codeday/productivity/entity/User.java
@@ -1,15 +1,14 @@
 package com.codeday.productivity.entity;
 
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.Id;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
-import jakarta.persistence.Column;
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 
 
 @Entity
@@ -43,5 +42,8 @@ public class User {
     @Column(nullable = false, columnDefinition = "TIMESTAMP")
     private Instant lastUpdated;
 
-}
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    @JsonManagedReference(value="user-reminder")
+    private List<Reminder> reminders = new ArrayList<>();
 
+}

--- a/src/main/java/com/codeday/productivity/repository/ReminderRepository.java
+++ b/src/main/java/com/codeday/productivity/repository/ReminderRepository.java
@@ -1,0 +1,7 @@
+package com.codeday.productivity.repository;
+
+import com.codeday.productivity.entity.Reminder;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ReminderRepository extends JpaRepository<Reminder, Long> {
+}

--- a/src/main/java/com/codeday/productivity/service/ReminderService.java
+++ b/src/main/java/com/codeday/productivity/service/ReminderService.java
@@ -1,24 +1,36 @@
 package com.codeday.productivity.service;
 
 import com.codeday.productivity.entity.Reminder;
+import com.codeday.productivity.entity.User;
 import com.codeday.productivity.repository.ReminderRepository;
+import com.codeday.productivity.repository.UserRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class ReminderService {
 
-    private final ReminderRepository repository;
+    private final ReminderRepository reminderRepository;
+    private final UserRepository userRepository;
 
     @Autowired
-    public ReminderService(ReminderRepository repository) {
-        this.repository = repository;
+    public ReminderService(ReminderRepository reminderRepository, UserRepository userRepository) {
+        this.reminderRepository = reminderRepository;
+        this.userRepository = userRepository;
     }
 
-    public Reminder saveReminder(Reminder reminder) {
-        return repository.save(reminder);
+    public Iterable<Reminder> getUserReminders(Integer id) {
+        User _user = userRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        return _user.getReminders();
     }
 
-
-
+    public Reminder createUserReminder(Integer id, Reminder reminder) {
+        User _user = userRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
+        reminder.setUser(_user);
+        return  reminderRepository.save(reminder);
+    }
 }

--- a/src/main/java/com/codeday/productivity/service/ReminderService.java
+++ b/src/main/java/com/codeday/productivity/service/ReminderService.java
@@ -4,6 +4,8 @@ import com.codeday.productivity.entity.Reminder;
 import com.codeday.productivity.entity.User;
 import com.codeday.productivity.repository.ReminderRepository;
 import com.codeday.productivity.repository.UserRepository;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -11,6 +13,8 @@ import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class ReminderService {
+
+    private static final Logger LOGGER = LogManager.getLogger(ReminderService.class);
 
     private final ReminderRepository reminderRepository;
     private final UserRepository userRepository;
@@ -22,12 +26,14 @@ public class ReminderService {
     }
 
     public Iterable<Reminder> getUserReminders(Integer id) {
+        LOGGER.info("Finding all Reminders for User ID: {}", id);
         User _user = userRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
         return _user.getReminders();
     }
 
     public Reminder createUserReminder(Integer id, Reminder reminder) {
+        LOGGER.info("Saving Reminder: {} to the Repo", reminder);
         User _user = userRepository.findById(id)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "User not found"));
         reminder.setUser(_user);

--- a/src/main/java/com/codeday/productivity/service/ReminderService.java
+++ b/src/main/java/com/codeday/productivity/service/ReminderService.java
@@ -1,0 +1,24 @@
+package com.codeday.productivity.service;
+
+import com.codeday.productivity.entity.Reminder;
+import com.codeday.productivity.repository.ReminderRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class ReminderService {
+
+    private final ReminderRepository repository;
+
+    @Autowired
+    public ReminderService(ReminderRepository repository) {
+        this.repository = repository;
+    }
+
+    public Reminder saveReminder(Reminder reminder) {
+        return repository.save(reminder);
+    }
+
+
+
+}


### PR DESCRIPTION
closes #12 

We want a Reminder Entity along with this path and functionality for a User:
/users/{id}/reminders:
get: get all user reminders
post: create a user reminder

To test:
run the app
using Postman:
-create at least one User
at localhost:8080/api/v1/users/1/reminders:
-use a POST call to create a Reminder for the User
-use a GET call to retrieve the Reminders for the User

As of now the Reminder Entity contains only a String for the message, we need to add functionality to be able to schedule when reminders are sent to the client.
