### PR TITLE
feat: Add OpenAPI 3.0 dependencies for REST API documentation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
 			<artifactId>spring-boot-starter-web</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springdoc</groupId>
+			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+			<version>2.1.0</version>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter</artifactId>
 			<exclusions>

--- a/src/main/java/com/codeday/productivity/ProductivityApplication.java
+++ b/src/main/java/com/codeday/productivity/ProductivityApplication.java
@@ -32,6 +32,14 @@ public class ProductivityApplication {
 	 * This is the main method that serves as an entry point for the Java application.
 	 * When the application starts, it triggers the Spring Boot's SpringApplication
 	 * to bootstrap the app.
+	 * API documentation is available at:
+	 * <a href="https://codeday-productivity-app.azurewebsites.net/swagger-ui/index.html">
+	 * Swagger UI
+	 * </a>
+	 * OpenAPIs descriptions can be found at:
+	 * <a href="https://codeday-productivity-app.azurewebsites.net/v3/api-docs">
+	 * OpenAPI JSON
+	 * </a>
 	 *
 	 * @param args Arguments passed to the application. Not specifically used in this application.
 	 */
@@ -40,5 +48,6 @@ public class ProductivityApplication {
 
 		LOGGER.info("ProductivityApplication started successfully!");
 	}
+
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,4 @@ spring.datasource.password= ${DB_PASSWORD}
 spring.jpa.show-sql = true
 spring.jpa.hibernate.ddl-auto = update
 spring.jpa.properties.hibernate.dialect = org.hibernate.dialect.MySQLDialect
+springdoc.swagger-ui.operationsSorter=method


### PR DESCRIPTION
This commit introduces OpenAPI 3.0 dependencies to generate documentation for our Spring REST API automatically.

- OpenAPI dependencies have been added to the project's build configuration.
- API documentation is accessible at `/swagger-ui/,` and the JSON description is available at `/v3/api-docs`.
- Updated main application class to include comments on accessing the API documentation.

Related Issue:

Closes #32